### PR TITLE
Make dbsnap_verify support Aurora Cluster

### DIFF
--- a/aws_lambda.py
+++ b/aws_lambda.py
@@ -1,3 +1,9 @@
+from os import environ
+import logging
+log_level = environ.get("LOG_LEVEL", "INFO")
+logger = logging.getLogger("dbsnap")
+logger.setLevel(log_level)
+
 from dbsnap_verify import handler
 
 def lambda_handler(event, context):

--- a/dbsnap/database.py
+++ b/dbsnap/database.py
@@ -1,0 +1,148 @@
+from .utils import get_tags_for_rds_arn
+
+
+class Database(object):
+    """Normalise DB Instance and Cluster Descriptions into a single type."""
+
+    def __init__(self, identifier=None, description=None, session=None):
+
+        self.session = session
+
+        self.description = description
+
+        if identifier:
+            self.description = self.get_description_by_id(identifier)
+
+        if self.description:
+            self.setattrs_from_description()
+
+    def __bool__(self):
+        """Consider this object False if description is None."""
+        if self.description is None:
+            return False
+        return True
+
+    def get_description_by_id(self, identifier):
+        """Return Database object or None."""
+        try:
+            return self.session.describe_db_instances(DBInstanceIdentifier=identifier)[
+                "DBInstances"
+            ][0]
+        except self.session.exceptions.DBInstanceNotFoundFault:
+            pass
+
+        try:
+            return self.session.describe_db_clusters(DBClusterIdentifier=identifier)[
+                "DBClusters"
+            ][0]
+        except self.session.exceptions.DBClusterNotFoundFault:
+            pass
+
+    @property
+    def tags(self):
+        return get_tags_for_rds_arn(self.session, self.arn)
+
+    @property
+    def region(self):
+        return self.arn.split(":")[3]
+
+    @property
+    def is_cluster(self):
+        if "DBInstanceIdentifier" in self.description:
+            return False
+        if "DBClusterIdentifier" in self.description:
+            return True
+        raise LookupError(
+            "invalid description: missing 'DBClusterIdentifier' or 'DBInstanceIdentifier'"
+        )
+
+    def setattrs_from_description(self):
+        if self.is_cluster:
+            self.compose_cluster()
+        else:
+            self.compose_instance()
+
+    def _compose_common(self):
+        self.kms_key_id = self.description.get("KmsKeyId")
+        self.engine = self.description["Engine"]
+        self.engine_version = self.description["EngineVersion"]
+
+    def compose_instance(self):
+        self._compose_common()
+        self.status = self.description["DBInstanceStatus"]
+        self.arn = self.description["DBInstanceArn"]
+        self.id = self.description["DBInstanceIdentifier"]
+
+    def compose_cluster(self):
+        self._compose_common()
+        self.status = self.description["Status"]
+        self.arn = self.description["DBClusterArn"]
+        self.id = self.description["DBClusterIdentifier"]
+        self.cluster_member_descriptions = self.description.get("DBClusterMembers", [])
+        self.cluster_member_ids = [
+            m["DBInstanceIdentifier"] for m in self.cluster_member_descriptions
+        ]
+
+    @property
+    def cluster_members(self):
+        """Return a list of cluster member instance Database objects."""
+        if self.is_cluster:
+            return [
+                Database(identifier=i, session=self.session)
+                for i in self.cluster_member_ids
+            ]
+
+    def create_cluster_instance(
+        self, instance_identifier, instance_class="db.r4.large"
+    ):
+        """Create an instance for this cluster."""
+        if self.is_cluster:
+            self.session.create_db_instance(
+                DBInstanceIdentifier=instance_identifier,
+                DBClusterIdentifier=self.id,
+                Engine=self.engine,
+                EngineVersion=self.engine_version,
+                DBInstanceClass=instance_class,
+            )
+
+    def delete(self):
+        """Destroy the RDS instance or cluster."""
+        if self.is_cluster:
+            for member_id in self.cluster_member_ids:
+                self.session.delete_db_instance(
+                    DBInstanceIdentifier=member_id, SkipFinalSnapshot=True
+                )
+            self.session.delete_db_cluster(
+                DBClusterIdentifier=self.id, SkipFinalSnapshot=True
+            )
+        else:
+            self.session.delete_db_instance(
+                DBInstanceIdentifier=self.id, SkipFinalSnapshot=True
+            )
+
+    def get_events(self, event_catagories=None, duration=1440):
+        events = []
+        if not event_catagories:
+            event_catagories = []
+        events.extend(
+            self.session.describe_events(
+                SourceIdentifier=self.id,
+                SourceType="db-instance",
+                EventCategories=event_catagories,
+                Duration=duration,
+            )["Events"]
+        )
+        events.extend(
+            self.session.describe_events(
+                SourceIdentifier=self.id,
+                SourceType="db-cluster",
+                EventCategories=event_catagories,
+                Duration=duration,
+            )["Events"]
+        )
+        return events
+
+    @property
+    def event_messages(self, event_catagories=None, duration=1440):
+        events = self.get_events(event_catagories, duration)
+        return [i["Message"] for i in events]

--- a/dbsnap_verify/__main__.py
+++ b/dbsnap_verify/__main__.py
@@ -4,6 +4,19 @@ import json
 
 from . import handler
 
+from os import environ
+import logging
+
+log_level = environ.get("LOG_LEVEL", "INFO")
+logger = logging.getLogger("dbsnap")
+logger.setLevel(log_level)
+
+from sys import stdout
+
+ch = logging.StreamHandler(stdout)
+ch.setLevel(log_level)
+logger.addHandler(ch)
+
 
 def main():
     parser = argparse.ArgumentParser(description="verify AWS RDS DB snapshots.")

--- a/dbsnap_verify/state_doc.py
+++ b/dbsnap_verify/state_doc.py
@@ -8,7 +8,7 @@ import boto3
 
 from dbsnap.rds_funcs import dbsnap_verify_identifier
 
-DB_ID_PREFIX_LEN = 14
+DB_ID_PREFIX_LEN = 5
 
 try:
     basestring
@@ -28,7 +28,10 @@ class DocToObject(object):
 
     def setattrs_from_dict(self, dictionary):
         for key, value in dictionary.items():
-            setattr(self, key, value)
+            try:
+                setattr(self, key, value)
+            except AttributeError:
+                pass
 
     def __init__(self, document=None):
         """document (json/dictionary): a document to turn into an object."""

--- a/setup.py
+++ b/setup.py
@@ -1,52 +1,37 @@
+
 # installation: pip install dbsnap_verify
-from setuptools import (
-  setup,
-  find_packages,
-)
+from setuptools import setup, find_packages
 
-setup( 
-    name = 'dbsnap',
-    version = '0.1.0',
-    description = 'Tools for copying and verifying AWS RDS snapshots.',
-    keywords = 'aws rds snapshot tool infrastructure copy verify',
-    long_description = open('README.rst').read(),
-
-    author = 'Russell Ballestrini',
-    author_email = 'russell@remind101.com',
-    url = 'https://github.com/remind101/dbsnap',
-
-    license='New BSD license',
-
-    packages = find_packages(),
-
-    install_requires = [
-        'boto3',
-        'botocore>=1.6.0',
-    ],
-    tests_require = [
-        'nose',
-        'mock',
-        'funcsigs',
-        'flake8',
-        'pytest',
-    ],
-    setup_requires=['pytest-runner'],
-    entry_points = {
-      'console_scripts': [
-        'dbsnap-verify = dbsnap_verify.__main__:main',
-        'dbsnap-copy = dbsnap_copy.__main__:main',
-      ],
+setup(
+    name="dbsnap",
+    version="0.1.0",
+    description="Tools for copying and verifying AWS RDS snapshots.",
+    keywords="aws rds snapshot tool infrastructure copy verify",
+    long_description=open("README.rst").read(),
+    author="Russell Ballestrini",
+    author_email="russell@remind101.com",
+    url="https://github.com/remind101/dbsnap",
+    license="New BSD license",
+    packages=find_packages(),
+    install_requires=["boto3", "botocore>=1.6.0"],
+    tests_require=["nose", "mock", "funcsigs", "flake8", "pytest"],
+    setup_requires=["pytest-runner"],
+    entry_points={
+        "console_scripts": [
+            "dbsnap-verify = dbsnap_verify.__main__:main",
+            "dbsnap-copy = dbsnap_copy.__main__:main",
+        ]
     },
     classifiers=[
-        'Intended Audience :: Developers, Operators, System Administrators',
-        'Natural Language :: English',
-        'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
+        "Intended Audience :: Developers, Operators, System Administrators",
+        "Natural Language :: English",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
     ],
 )
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,36 @@
+from test_helper import TestHelper
+from dbsnap.database import Database
+
+
+class TestDatabase(TestHelper):
+    def test_database_by_id(self):
+        session = self._magic_rds_session()
+        session.describe_db_instances.return_value = self.db_instance_desc_1
+        session.describe_db_clusters.side_effect = self.rds.exceptions.DBClusterNotFoundFault(
+            {}, ""
+        )
+        database = Database(session=session, identifier="instanceX")
+        self.assertEqual(database.id, "instance1")
+
+    def test_database_by_id_is_none(self):
+        session = self._magic_rds_session()
+        session.describe_db_instances.side_effect = self.rds.exceptions.DBInstanceNotFoundFault(
+            {}, ""
+        )
+        session.describe_db_clusters.side_effect = self.rds.exceptions.DBClusterNotFoundFault(
+            {}, ""
+        )
+        database = Database(session=session, identifier="instanceX")
+        self.assertEqual(database.description, None)
+
+    def test_database_by_description(self):
+        session = self._magic_rds_session()
+        database = Database(
+            session=session, description=self.db_instance_desc_1["DBInstances"][0]
+        )
+        self.assertEqual(database.id, "instance1")
+
+    def test_malformed_database_description(self):
+        session = self._magic_rds_session()
+        with self.assertRaises(LookupError):
+            Database(session=session, description=self.db_instance_desc_3)

--- a/tests/test_datadog_output.py
+++ b/tests/test_datadog_output.py
@@ -5,13 +5,13 @@ from dbsnap_verify.datadog_output import (
     datadog_lambda_metric_output,
 )
 
-class Tests(unittest.TestCase):
 
+class Tests(unittest.TestCase):
     def test_datadog_check_ok(self):
         output = datadog_lambda_check_output(
             metric_name="dbsnap-verify.lambda",
             metric_value="OK",
-            metric_tags={"database" : "test-db-instance"}
+            metric_tags={"database": "test-db-instance"},
         )
         self.assertIn("|#database:test-db-instance", output)
         self.assertIn("MONITORING|", output)
@@ -21,7 +21,7 @@ class Tests(unittest.TestCase):
         output = datadog_lambda_check_output(
             metric_name="dbsnap-verify.lambda",
             metric_value="CRITICAL",
-            metric_tags={"database" : "test-db-instance"}
+            metric_tags={"database": "test-db-instance"},
         )
         self.assertIn("|#database:test-db-instance", output)
         self.assertIn("MONITORING|", output)
@@ -31,7 +31,7 @@ class Tests(unittest.TestCase):
         output = datadog_lambda_check_output(
             metric_name="dbsnap-verify.lambda",
             metric_value="OK",
-            metric_tags={"database" : "test-db-instance", "another" : 3}
+            metric_tags={"database": "test-db-instance", "another": 3},
         )
         self.assertIn("|#database:test-db-instance,another:3", output)
 
@@ -39,7 +39,7 @@ class Tests(unittest.TestCase):
         output = datadog_lambda_check_output(
             metric_name="dbsnap-verify.lambda",
             metric_value="CRITICAL",
-            metric_tags="database:test-db-instance"
+            metric_tags="database:test-db-instance",
         )
         self.assertIn("|#database:test-db-instance", output)
 
@@ -47,7 +47,7 @@ class Tests(unittest.TestCase):
         output = datadog_lambda_check_output(
             metric_name="dbsnap-verify.lambda",
             metric_value="CRITICAL",
-            metric_tags="#database:test-db-instance"
+            metric_tags="#database:test-db-instance",
         )
         self.assertIn("|#database:test-db-instance", output)
 
@@ -55,7 +55,7 @@ class Tests(unittest.TestCase):
         output = datadog_lambda_check_output(
             metric_name="dbsnap-verify.lambda",
             metric_value="CRITICAL",
-            metric_tags=["database:test-db-instance", "another"]
+            metric_tags=["database:test-db-instance", "another"],
         )
         self.assertIn("|#database:test-db-instance,another", output)
 
@@ -65,5 +65,5 @@ class Tests(unittest.TestCase):
                 metric_name="dbsnap-verify.lambda",
                 metric_type="taco",
                 metric_value=42,
-                metric_tags=["database:test-db-instance", "another"]
+                metric_tags=["database:test-db-instance", "another"],
             )

--- a/tests/test_dbsnap_copy.py
+++ b/tests/test_dbsnap_copy.py
@@ -15,7 +15,6 @@ from dbsnap_copy import (
 
 
 class TestDbSnapcopy(unittest.TestCase):
-
     def test_invalid_parse_source(self):
         source = "bad_source"
         with self.assertRaises(ValueError):
@@ -48,7 +47,7 @@ class TestDbSnapcopy(unittest.TestCase):
             scenario(":", source_region, None),
             scenario("us-west-1:", "us-west-1", None),
             scenario(":my-snap", source_region, "my-snap"),
-            scenario("us-west-1:my-snap", "us-west-1", "my-snap")
+            scenario("us-west-1:my-snap", "us-west-1", "my-snap"),
         )
 
         for t in tests:
@@ -71,9 +70,8 @@ class TestDbSnapcopy(unittest.TestCase):
     def test_get_snapshot_target_name(self):
         now = datetime.utcfromtimestamp(0)
         r = get_snapshot_target_name(
-            Dest("us-east-1", "my-snap"), "source", "us-east-1", now)
+            Dest("us-east-1", "my-snap"), "source", "us-east-1", now
+        )
         self.assertEqual(r, "my-snap")
-        r = get_snapshot_target_name(
-            Dest("us-east-1", ""), "source", "us-east-1", now)
+        r = get_snapshot_target_name(Dest("us-east-1", ""), "source", "us-east-1", now)
         self.assertEqual(r, "source-copy-us-east-1-19700101T000000Z")
-

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -1,0 +1,118 @@
+import unittest
+import mock
+import boto3
+
+
+class TestHelper(unittest.TestCase):
+    def _magic_rds_session(self):
+        session = mock.MagicMock()
+        session.exceptions.DBInstanceNotFoundFault = (
+            self.rds.exceptions.DBInstanceNotFoundFault
+        )
+        session.exceptions.DBClusterNotFoundFault = (
+            self.rds.exceptions.DBClusterNotFoundFault
+        )
+        return session
+
+    def setUp(self):
+        self.rds = boto3.client("rds", region_name="us-east-1")
+        self.fake_snapshot_desc = {
+            "DBSnapshots": [
+                {
+                    "DBSnapshotIdentifier": "rds:snapshot1",
+                    "DBSnapshotArn": "arn:1",
+                    "Engine": "postgres",
+                    "EngineVersion": "9.6.6",
+                    "Status": "available",
+                    "SnapshotType": "manual",
+                    "SnapshotCreateTime": 1,
+                },
+                {
+                    "DBSnapshotIdentifier": "rds:snapshot2",
+                    "DBSnapshotArn": "arn:2",
+                    "Engine": "postgres",
+                    "EngineVersion": "9.6.6",
+                    "Status": "available",
+                    "SnapshotType": "manual",
+                    "SnapshotCreateTime": 2.3,
+                },
+                {
+                    "DBSnapshotIdentifier": "rds:snapshot3",
+                    "DBSnapshotArn": "arn:3",
+                    "Engine": "postgres",
+                    "EngineVersion": "9.6.6",
+                    "Status": "available",
+                    "SnapshotType": "manual",
+                    "SnapshotCreateTime": 10,
+                },
+                # Note: only available snapshots have a SnapshotCreateTime.
+                {
+                    "DBSnapshotIdentifier": "rds:snapshot4",
+                    "DBSnapshotArn": "arn:4",
+                    "Engine": "postgres",
+                    "EngineVersion": "9.6.6",
+                    "Status": "pending",
+                    "SnapshotType": "manual",
+                },
+                {
+                    "DBSnapshotIdentifier": "rds:snapshot5",
+                    "DBSnapshotArn": "arn:5",
+                    "Engine": "postgres",
+                    "EngineVersion": "9.6.6",
+                    "Status": "available",
+                    "SnapshotType": "manual",
+                    "SnapshotCreateTime": 8,
+                },
+                {
+                    "DBSnapshotIdentifier": "rds:snapshot6",
+                    "DBSnapshotArn": "arn:6",
+                    "Engine": "postgres",
+                    "EngineVersion": "9.6.6",
+                    "Status": "available",
+                    "SnapshotType": "manual",
+                    "SnapshotCreateTime": 9,
+                },
+            ]
+        }
+        self.db_instance_desc_1 = {
+            "DBInstances": [
+                {
+                    "DBInstanceIdentifier": "instance1",
+                    "DBInstanceStatus": "available",
+                    "DBInstanceArn": "arn:1234",
+                    "InstanceCreateTime": 100,
+                    "Engine": "postgres",
+                    "EngineVersion": "9.6.6",
+                }
+            ]
+        }
+        self.db_instance_desc_2 = {
+            "DBInstances": [
+                {
+                    "DBClusterIdentifier": "instance2",
+                    "DBClusterArn": "arn:1234",
+                    "Status": "creating",
+                    "InstanceCreateTime": 100,
+                    "Engine": "aurora-postgres",
+                    "EngineVersion": "9.6.6",
+                }
+            ]
+        }
+        # example malformed database description.
+        self.db_instance_desc_3 = {"bad": "data"}
+
+        self.fake_tags = {
+            "arn:1": {"TagList": [{"Key": "created_by", "Value": "dbsnap-copy"}]},
+            "arn:2": {"TagList": [{"Key": "created_by", "Value": "dbsnap-copy"}]},
+            "arn:3": {"TagList": [{"Key": "created_by", "Value": "dbsnap-copy"}]},
+            "arn:4": {"TagList": [{"Key": "created_by", "Value": "dbsnap-copy"}]},
+            "arn:5": {"TagList": [{"Key": "created_by", "Value": "dbsnap-copy"}]},
+            "arn:6": {"TagList": [{"Key": "created_by", "Value": "not-dbsnap-copy"}]},
+            "arn:7": {"TagList": []},
+        }
+
+        def fake_list_tags_for_resource(ResourceName):
+            return self.fake_tags[ResourceName]
+
+        self.fake_list_tags = fake_list_tags_for_resource
+

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,13 +5,31 @@ import mock
 import json
 
 import boto3
+
 s3 = boto3.client("s3")
 
 from dbsnap_verify.state_doc import get_or_create_state_doc
 
-SNS_RDS_EVENT = {'Records': [{'EventSource': 'aws:sns', 'EventVersion': '1.0', 'EventSubscriptionArn': 'arn:aws:sns:us-west-1:12345678:test-dbsnap-verify-sns-rds-to-lambda', 'Sns': {'Type': 'Notification', 'MessageId': '9e677600-xxxx-xxxx-xxxx-251700e3b3f1', 'TopicArn': 'arn:aws:sns:us-west-1:12345678:test-dbsnap-verify-sns-rds-to-lambda', 'Subject': 'RDS Notification Message', 'Message': '{"Event Source":"db-instance","Event Time":"2018-03-05 18:22:14.893","Source ID":"dbsnap-verify-test-db-instance","Event ID":"http://docs.amazonwebservices.com/AmazonRDS/latest/UserGuide/USER_Events.html#RDS-EVENT-0043","Event Message":"Restored from snapshot rds-test-db-instance-2018-03-04-12-12-copy-us-east-1-20180304t171502z"}', 'Timestamp': '2018-03-05T18:22:36.320Z', 'MessageAttributes': {}}}]}
+SNS_RDS_EVENT = {
+    "Records": [
+        {
+            "EventSource": "aws:sns",
+            "EventVersion": "1.0",
+            "EventSubscriptionArn": "arn:aws:sns:us-west-1:12345678:test-dbsnap-verify-sns-rds-to-lambda",
+            "Sns": {
+                "Type": "Notification",
+                "MessageId": "9e677600-xxxx-xxxx-xxxx-251700e3b3f1",
+                "TopicArn": "arn:aws:sns:us-west-1:12345678:test-dbsnap-verify-sns-rds-to-lambda",
+                "Subject": "RDS Notification Message",
+                "Message": '{"Event Source":"db-instance","Event Time":"2018-03-05 18:22:14.893","Source ID":"dbsnap-verify-test-db-instance","Event ID":"http://docs.amazonwebservices.com/AmazonRDS/latest/UserGuide/USER_Events.html#RDS-EVENT-0043","Event Message":"Restored from snapshot rds-test-db-instance-2018-03-04-12-12-copy-us-east-1-20180304t171502z"}',
+                "Timestamp": "2018-03-05T18:22:36.320Z",
+                "MessageAttributes": {},
+            },
+        }
+    ]
+}
 
-with open('./tests/fixtures/example_state_doc.json') as state_doc_file:
+with open("./tests/fixtures/example_state_doc.json") as state_doc_file:
     JSON_STATE_DOC = state_doc_file.read()
 
 mock_state_doc = mock.Mock(return_value=JSON_STATE_DOC)
@@ -19,22 +37,23 @@ mock_no_such_key_exception = mock.Mock(side_effect=s3.exceptions.NoSuchKey({}, "
 mock_none = mock.Mock(return_value=None)
 
 
-@mock.patch('dbsnap_verify.state_doc.StateDoc._save_state_doc_in_s3', mock_none)
-@mock.patch('dbsnap_verify.state_doc.StateDoc._save_state_doc_in_path', mock_none)
+@mock.patch("dbsnap_verify.state_doc.StateDoc._save_state_doc_in_s3", mock_none)
+@mock.patch("dbsnap_verify.state_doc.StateDoc._save_state_doc_in_path", mock_none)
 class Tests(unittest.TestCase):
-
     def setUp(self):
         # mock the static json config in the Cloudwatch event rule trigger.
         # an AWS Lambda always accepts `event` as its first argument.
         self.event = {
-            "database" : "test-db-instance",
-            "state_doc_bucket" : "bucket-to-hold-state-documents",
-            "snapshot_region" : "us-east-1",
+            "database": "test-db-instance",
+            "state_doc_bucket": "bucket-to-hold-state-documents",
+            "snapshot_region": "us-east-1",
             "database_subnet_ids": "subnet-32220000,subnet-df7d0000,subnet-b39e0000,subnet-40040000",
             "database_security_group_ids": "sg-33de0000",
         }
 
-    @mock.patch('dbsnap_verify.state_doc.StateDoc._load_state_doc_from_s3', mock_state_doc)
+    @mock.patch(
+        "dbsnap_verify.state_doc.StateDoc._load_state_doc_from_s3", mock_state_doc
+    )
     def test_get_or_create_state_doc_in_s3_doc_found_in_s3(self):
         state_doc = get_or_create_state_doc(self.event)
         self.assertEqual(state_doc.database, "test-db-instance")
@@ -42,7 +61,10 @@ class Tests(unittest.TestCase):
         self.assertGreater(len(state_doc.states), 5)
         self.assertEqual(state_doc.current_state, "wait")
 
-    @mock.patch('dbsnap_verify.state_doc.StateDoc._load_state_doc_from_s3', mock_no_such_key_exception)
+    @mock.patch(
+        "dbsnap_verify.state_doc.StateDoc._load_state_doc_from_s3",
+        mock_no_such_key_exception,
+    )
     def test_get_or_create_state_doc_in_s3_missing_key(self):
         """Returns a new state_doc when one is not found in s3"""
         state_doc = get_or_create_state_doc(self.event)
@@ -52,9 +74,12 @@ class Tests(unittest.TestCase):
         self.assertEqual(len(state_doc.states), 1)
         self.assertEqual(state_doc.current_state, "wait")
 
-    @mock.patch('dbsnap_verify.state_doc.StateDoc._load_state_doc_from_s3', mock_state_doc)
+    @mock.patch(
+        "dbsnap_verify.state_doc.StateDoc._load_state_doc_from_s3", mock_state_doc
+    )
     def test_get_or_create_state_doc_from_sns_rds_event_found(self):
         from os import environ
+
         environ["STATE_DOC_BUCKET"] = "bucket-to-hold-state-documents"
         state_doc = get_or_create_state_doc(SNS_RDS_EVENT)
         self.assertEqual(state_doc.database, "test-db-instance")
@@ -62,9 +87,13 @@ class Tests(unittest.TestCase):
         self.assertGreater(len(state_doc.states), 5)
         self.assertEqual(state_doc.current_state, "wait")
 
-    @mock.patch('dbsnap_verify.state_doc.StateDoc._load_state_doc_from_s3', mock_no_such_key_exception)
+    @mock.patch(
+        "dbsnap_verify.state_doc.StateDoc._load_state_doc_from_s3",
+        mock_no_such_key_exception,
+    )
     def test_sns_rds_event_not_found_in_s3(self):
         from os import environ
+
         environ["STATE_DOC_BUCKET"] = "bucket-to-hold-state-documents"
         state_doc = get_or_create_state_doc(SNS_RDS_EVENT)
         self.assertEqual(state_doc, None)

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -78,4 +78,3 @@ class TestSnapshot(unittest.TestCase):
     def test_malformed_snapshot_description(self):
         with self.assertRaises(LookupError):
             Snapshot(self.snapshot_description3)
-


### PR DESCRIPTION
Adding in support for Aurora restores.
Adding additional saftey when I run into errors.

	new file:   dbsnap/database.py
	modified:   dbsnap/rds_funcs.py
	modified:   dbsnap/snapshot.py
	modified:   dbsnap_verify/__init__.py
	modified:   dbsnap_verify/state_doc.py
	modified:   tests/test_datadog_output.py
	modified:   tests/test_dbsnap_copy.py
	modified:   tests/test_integration.py
	modified:   tests/test_rds_funcs.py
	modified:   tests/test_snapshot.py
	modified:   tests/test_state_doc.py

TODO
========

- [x] figure out why a cluster has an empty list of rds events